### PR TITLE
Add Nitrogen systems to the API

### DIFF
--- a/DeathrunRemade/DeathrunAPI.cs
+++ b/DeathrunRemade/DeathrunAPI.cs
@@ -64,5 +64,48 @@ namespace DeathrunRemade
         {
             return Enum.GetValues(DeathrunInit._Config.PersonalCrushDepth.Value.GetType()).Length - 1;
         }
+
+        /// <inheritdoc cref="AddNitrogenModifier(TechType,IEnumerable{float})"/>
+        public static void AddNitrogenModifier(TechType suit, float modifier)
+        {
+            AddNitrogenModifier(suit, new[] { modifier });
+        }
+
+        /// <summary>
+        /// Register a custom equipment item with its associated nitrogen modifier values.<br />
+        /// Nitrogen modifier values of items may need to change depending on difficulty. If you pass more than one
+        /// value they are associated with the difficulty in ascending order. The first value is associated with HARD,
+        /// the next with DEATHRUN, and so on. If you pass only one value or the difficulty is higher than the number of
+        /// values you passed, the <em>last</em> value you passed will be used (i.e. the one associated with the highest
+        /// difficulty).
+        /// Note: These values are <em>multipliers</em> for the nitrogen accumulation rate. A value of 0.5 will halve the
+        /// accumulation rate, 1.0 will completely negate it, and -1.0 will double it.
+        /// </summary>
+        public static void AddNitrogenModifier(TechType suit, IEnumerable<float> modifier)
+        {
+            NitrogenHandler.AddNitrogenModifier(suit, modifier);
+        }
+
+        /// <summary>
+        /// Try to get the existing nitrogen modifier values for a <see cref="TechType"/>. This is useful if you want to
+        /// add a custom equipment item with values that match e.g. the vanilla reinforced suit.
+        /// </summary>
+        /// <param name="suit">The <see cref="TechType"/> of the equipment item you want to find values of.</param>
+        /// <param name="modifier"> The custom nitrogen modifier values of the equipment item in ascending order. The
+        /// first element will be for HARD difficulty, the next for DEATHRUN, and so on.</param>
+        /// <returns> True if the equipment item has a nitrogen modifier entry, false if it does not.</returns>
+        public static bool TryGetNitrogenModifier(TechType suit, out float[] modifier)
+        {
+            return NitrogenHandler.TryGetNitrogenModifier(suit, out modifier);
+        }
+
+        /// <summary>
+        /// Get the number of distinct difficulty levels for nitrogen modifier. This value determines how many
+        /// different modifiers can be added to <see cref="AddNitrogenModifier(TechType,IEnumerable{float})"/>.
+        /// </summary>
+        public static int GetNumNitrogenDifficulties()
+        {
+            return Enum.GetValues(DeathrunInit._Config.NitrogenBends.Value.GetType()).Length - 1;
+        }
     }
 }

--- a/DeathrunRemade/DeathrunInit.cs
+++ b/DeathrunRemade/DeathrunInit.cs
@@ -316,6 +316,7 @@ namespace DeathrunRemade
             new Suit(Suit.Variant.ReinforcedSuitMk2).Register();
             new Suit(Suit.Variant.ReinforcedSuitMk3).Register();
             Suit.RegisterCrushDepths();
+            Suit.RegisterNitrogenModifiers();
             PDAScanner.onAdd += Suit.UnlockSuitOnScanFish;
             
             new Tank(Tank.Variant.ChemosynthesisTank).Register();

--- a/DeathrunRemade/Items/Suit.cs
+++ b/DeathrunRemade/Items/Suit.cs
@@ -201,6 +201,18 @@ namespace DeathrunRemade.Items
         }
 
         /// <summary>
+        /// Register the nitrogen modifiers of all suits to the <see cref="NitrogenHandler"/>.
+        /// </summary>
+        public static void RegisterNitrogenModifiers()
+        {
+            // Using our own API for this rather than internal methods catches any issues with the API much earlier.
+            // TODO: add more values for the other difficulties.
+            DeathrunAPI.AddNitrogenModifier(ReinforcedFiltration, new[] { 0.25f });
+            DeathrunAPI.AddNitrogenModifier(ReinforcedMk2, new[] { 0.25f });
+            DeathrunAPI.AddNitrogenModifier(ReinforcedMk3, new[] { 0.45f });
+        }
+
+        /// <summary>
         /// Get the temperature limit of the given suit.
         /// </summary>
         public static float GetTemperatureLimit(TechType techType)


### PR DESCRIPTION

Added Nitrogen API calls to match the Crush Depth API
Reworked the GetAccumulationModifier to pull from the new Dictionary.
Ensured modifier can not be negative but people could still actually increase the drain by adding a negative value if they really want.
For once in my life actually put in documentation for the things I added about how they work.

Feel free to rework as you see fit as this is really just my initial thoughts and you may want to do it another way.

Though if you do please still allow for all equipment slots to be considered instead of just body and head as I have some idea's for extra gear.  { Gloves, Chips, etc. }