### PR TITLE
disable special mob drops when relevant settings are disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea/
 /.vs/
+/.vscode/
 packages
 Releases
 **/bin

--- a/DeathrunRemade/Items/LavaLizardScale.cs
+++ b/DeathrunRemade/Items/LavaLizardScale.cs
@@ -1,3 +1,5 @@
+using DeathrunRemade.Configuration;
+using DeathrunRemade.Objects.Enums;
 using HootLib;
 using Nautilus.Assets;
 using Nautilus.Handlers;
@@ -21,6 +23,11 @@ namespace DeathrunRemade.Items
         protected override Atlas.Sprite GetSprite()
         {
             return Hootils.LoadSprite("lavalizardscale.png", true);
+        }
+
+        protected override bool ShouldActivateForConfig(ConfigSave config)
+        {
+            return config.PersonalCrushDepth > Difficulty3.Hard;
         }
 
         protected override void RegisterHarvestData()

--- a/DeathrunRemade/Items/MobDropBase.cs
+++ b/DeathrunRemade/Items/MobDropBase.cs
@@ -27,11 +27,6 @@ namespace DeathrunRemade.Items
 
             return prefab;
         }
-        
-        protected override bool ShouldActivateForConfig(ConfigSave config)
-        {
-            return true;
-        }
 
         protected override void Register()
         {

--- a/DeathrunRemade/Items/SpineEelScale.cs
+++ b/DeathrunRemade/Items/SpineEelScale.cs
@@ -1,3 +1,5 @@
+using DeathrunRemade.Configuration;
+using DeathrunRemade.Objects.Enums;
 using HootLib;
 using Nautilus.Assets;
 using Nautilus.Handlers;
@@ -21,6 +23,11 @@ namespace DeathrunRemade.Items
         protected override Atlas.Sprite GetSprite()
         {
             return Hootils.LoadSprite("rivereelscale.png", true);
+        }
+
+        protected override bool ShouldActivateForConfig(ConfigSave config)
+        {
+            return config.PersonalCrushDepth > Difficulty3.Hard;
         }
 
         protected override void RegisterHarvestData()

--- a/DeathrunRemade/Items/SuitBase.cs
+++ b/DeathrunRemade/Items/SuitBase.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using DeathrunRemade.Configuration;
+using DeathrunRemade.Objects.Enums;
 using HootLib;
 using Nautilus.Assets;
 using Nautilus.Assets.Gadgets;
@@ -46,7 +47,7 @@ namespace DeathrunRemade.Items
         
         protected override bool ShouldActivateForConfig(ConfigSave config)
         {
-            return true;
+            return config.PersonalCrushDepth > Difficulty3.Hard;
         }
 
         protected override void Register()

--- a/DeathrunRemade/Items/ThermophileSample.cs
+++ b/DeathrunRemade/Items/ThermophileSample.cs
@@ -1,3 +1,4 @@
+using DeathrunRemade.Configuration;
 using HootLib;
 using Nautilus.Assets;
 using Nautilus.Handlers;
@@ -21,6 +22,11 @@ namespace DeathrunRemade.Items
         protected override Atlas.Sprite GetSprite()
         {
             return Hootils.LoadSprite("thermophilesample.png", true);
+        }
+
+        protected override bool ShouldActivateForConfig(ConfigSave config)
+        {
+            return config.SpecialAirTanks;
         }
 
         protected override void RegisterHarvestData()


### PR DESCRIPTION
Fixes #18:
- Lava Larvae will not drop Thermophile Samples if "Enable Special Air Tanks" config setting is false.
- River Prowlers and Lava Lizards will not drop their respective scales if "Personal Crush Depth" config setting is "Hard" or "Normal".
- Reinforced Suit blueprints will not activate if "Personal Crush Depth" config setting is "Hard" or "Normal".