### PR TITLE
fix not being able to use fabricator in creative mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea/
 /.vs/
+/.vscode/
 packages
 Releases
 **/bin

--- a/DeathrunRemade/Patches/PowerPatcher.cs
+++ b/DeathrunRemade/Patches/PowerPatcher.cs
@@ -70,8 +70,8 @@ namespace DeathrunRemade.Patches
         [HarmonyPatch(typeof(CrafterLogic), nameof(CrafterLogic.ConsumeEnergy))]
         private static bool PreventFabricatorConsumption(PowerRelay powerRelay, float amount, ref bool __result)
         {
-            // Don't do anything when NoCost cheat is active.
-            if (GameModeUtils.IsCheatActive(GameModeOption.NoCost))
+            // Don't do anything when NoCost cheat is active or game mode is creative.
+            if (GameModeUtils.IsCheatActive(GameModeOption.NoCost) || (GameModeUtils.currentGameMode == GameModeOption.Creative))
                 return true;
             
             amount = ModifyConsumeEnergy(amount, IsInRadiation(powerRelay));


### PR DESCRIPTION
If you create a base in creative mode, by default you will not be able to use the fabricator because of insufficient power.

Currently, the function that stops you from using the fabricator if you don't have enough power only checks if the NoCost cheat is active. This PR also adds a check for if the game mode is set to creative.