### PR TITLE
add correct textures for Reinforced Suit Mk2/3 & Reinforced Water Filtration Suit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea/
 /.vs/
+/.vscode/
 packages
 Releases
 **/bin

--- a/DeathrunRemade/Patches/SuitPatcher.cs
+++ b/DeathrunRemade/Patches/SuitPatcher.cs
@@ -69,22 +69,22 @@ namespace DeathrunRemade.Patches
                 return;
             }
 
-            // The default name for textures.
-            string textureName = "_MainTex";
+            string defaultTextureName = "_MainTex";
+
             // Get GameObjects for the default suit and the suit we want to clone.
             Transform geo = Player.main.transform.Find("body/player_view/male_geo");
-            GameObject suitClone = geo.Find(suitClonePath).gameObject;
-            GameObject suitDefault = geo.Find("diveSuit/diveSuit_body_geo").gameObject;
+            GameObject cloneSuit = geo.Find(suitClonePath).gameObject;
+            GameObject defaultSuit = geo.Find("diveSuit/diveSuit_body_geo").gameObject;
             // Get renderer and texture for the clone suit.
-            Renderer renderer = suitClone.GetComponent<Renderer>();
-            Texture texture = renderer.material.GetTexture(textureName);
+            Renderer renderer = cloneSuit.GetComponent<Renderer>();
+            Texture texture = renderer.material.GetTexture(defaultTextureName);
 
             // Activate the model for the clone suit, and deactivate the default suit model.
-            suitClone.SetActive(true);
-            suitDefault.SetActive(false);
+            cloneSuit.SetActive(true);
+            defaultSuit.SetActive(false);
 
             // Set the suit texture.
-            renderer.materials[0].SetTexture(textureName, (Texture2D)texture);
+            renderer.materials[0].SetTexture(defaultTextureName, (Texture2D)texture);
         }
     }
 

--- a/DeathrunRemade/Patches/SuitPatcher.cs
+++ b/DeathrunRemade/Patches/SuitPatcher.cs
@@ -87,5 +87,4 @@ namespace DeathrunRemade.Patches
             renderer.materials[0].SetTexture(defaultTextureName, (Texture2D)texture);
         }
     }
-
 }


### PR DESCRIPTION
It was annoying me that the Reinforced Mk2/3 suits and Reinforced Water Filtration Suit were using the default suit texture when worn instead of the texture for the suits they are based on, so I added a method to `SuitPatcher` to make them use the appropriate textures.

(With thanks to @Indigocoder1, since looking at his SuitLib code was extremely helpful in figuring out how to do this.)