### PR TITLE
Scoring fixes

### DIFF
--- a/DeathrunRemade/Components/RunStatsUI/RunStatsRow.cs
+++ b/DeathrunRemade/Components/RunStatsUI/RunStatsRow.cs
@@ -57,7 +57,7 @@ namespace DeathrunRemade.Components.RunStatsUI
             causeOfDeath.text = Stats.causeOfDeath;
             deaths.text = $"{Stats.deaths}";
             scoreMult.text = $"{Stats.scoreMult:F1}x";
-            score.text = $"{Stats.scoreBase * Stats.scoreMult:F0}";
+            score.text = $"{Stats.scoreTotal:F0}";
         }
     }
 }

--- a/DeathrunRemade/Objects/DeathrunStats.cs
+++ b/DeathrunRemade/Objects/DeathrunStats.cs
@@ -50,7 +50,7 @@ namespace DeathrunRemade.Objects
             var settings = GetSerializerSettings();
             try
             {
-                StreamReader reader = new StreamReader(fileName);
+                using StreamReader reader = new StreamReader(fileName);
                 string json = await reader.ReadToEndAsync();
                 return JsonConvert.DeserializeObject<DeathrunStats>(json, settings);
             }

--- a/DeathrunRemade/Objects/Enums/RunAchievements.cs
+++ b/DeathrunRemade/Objects/Enums/RunAchievements.cs
@@ -38,6 +38,16 @@ namespace DeathrunRemade.Objects.Enums
     internal static class RunAchievementsExtensions
     {
         /// <summary>
+        /// Check whether the player has not unlocked any part of a flag. Useful for checking with flags that combine
+        /// multiple conditions into one, like the No Vehicle Challenge.
+        /// </summary>
+        public static bool IsCompletelyLocked(this RunAchievements achievements, RunAchievements flag)
+        {
+            // If this zeroes out it means none of the flags checked for were active.
+            return (achievements & flag) == RunAchievements.None;
+        }
+        
+        /// <summary>
         /// Check whether the player has managed to unlock a specific flag.
         /// </summary>
         public static bool IsUnlocked(this RunAchievements achievements, RunAchievements flag)


### PR DESCRIPTION
- Scores in the best run UI correctly show the total score rather than base*mult.
- Rebalance speed vs survival score bonuses.
- All bonuses benefit from difficulty multiplier.
- Migrate and recalculate scores if they were saved with a different mod version.